### PR TITLE
Canonicalize lib names in deps.edn

### DIFF
--- a/resources/leiningen/new/clojure_graalvm_aws_lambda/deps.edn
+++ b/resources/leiningen/new/clojure_graalvm_aws_lambda/deps.edn
@@ -1,5 +1,5 @@
 {:deps      {org.clojure/clojure {:mvn/version "1.10.1"}
-             http-kit            {:mvn/version "2.3.0"}
+             http-kit/http-kit   {:mvn/version "2.3.0"}
              metosin/jsonista    {:mvn/version "0.2.4"}}
  :paths     ["src" "resources"]
  :mvn/repos {"central" {:url "https://repo1.maven.org/maven2/"}


### PR DESCRIPTION
Unqualified lib names are being deprecated in deps.edn and will warn